### PR TITLE
Minor fixes

### DIFF
--- a/penkins.py
+++ b/penkins.py
@@ -8,7 +8,6 @@ import os
 import sys
 import subprocess
 import logging
-<<<<<<< HEAD
 from penkins.__init__ import PenkinsConfig
 from penkins.__init__ import PenkinsMail
 

--- a/penkins.py
+++ b/penkins.py
@@ -8,9 +8,9 @@ import os
 import sys
 import subprocess
 import logging
-from penkins import PenkinsConfig
-from penkins import PenkinsMail
-
+from penkins.__init__ import PenkinsConfig
+from penkins.__init__ import PenkinsMail
+# please remove this line
 # repo = hgapi.Repo("http://repo.10k.anzhiganov.com/stackwebservices/id/server", "vanzhiganov")
 
 # clone

--- a/penkins/__init__.py
+++ b/penkins/__init__.py
@@ -10,6 +10,7 @@ class PenkinsConfig:
         self.config = self.__read(file_name)
 
     def __read(self, config_file):
+        config = yaml.load(open('.penkins-origin.yaml', 'r'))
         if os.path.isfile('.penkins.yaml'):
             config = yaml.load(open('.penkins.yaml', 'r'))
         return config


### PR DESCRIPTION
PenkinsConfig in `__init__` method tries to use `/var/lib/penkins/.penkins.yaml` as default parameter, but there's no such file yet.
Then PenkinsConfig in `__read` method tries to load `.penkins.yaml`, but it cannot be found.
So I offered to load default `.penkins-origin.yaml` file instead.

BTW, `__read` method has `config_file` parameter which isn't utilized in the method body.